### PR TITLE
feat: add authorizing github to docs

### DIFF
--- a/_docs_github/1_how-to-integrate.md
+++ b/_docs_github/1_how-to-integrate.md
@@ -11,3 +11,5 @@ You can add your Node.js and Ruby GitHub repos and quickly test them, or decide 
 3. Next, you’ll see a list of all GitHub repos across your GitHub organisations. Snyk automatically tests these repos, and you’ll see the test results, with the option to view a detailed test report.
 4. Clicking ‘Watch’ will add this repo as a project to Snyk. The watched repos appear in your projects, and will be continuously checked for vulnerabilities.
 5. "Open a fix PR" lets you fix vulnerabilities right away. You'll be able to review the suggested remediations, and create a PR with the required upgrades or patches.
+
+<div class="alert alert--inline alert--notice"><p class="alert__text">To view your organisation's projects in Snyk, you'll need to have <a href="#authorizing-github">sufficient access</a> to your organisation's repositories on GitHub.</p></div>

--- a/_docs_github/6_authorizing-github.md
+++ b/_docs_github/6_authorizing-github.md
@@ -1,0 +1,11 @@
+---
+title: Authorizing GitHub
+---
+
+To view your organisation's GitHub projects on Snyk, you will need to have sufficient user permissions. When you authenticate Snyk, GitHub will show you which organisations you can integrate.
+
+If you do not have the correct permissions, you will see "Access request pending" next to your ogranisation's name, and you will be unable to see this organisation's projects in Snyk.
+
+![Adding your GH repos](https://res.cloudinary.com/snyk/image/upload/f_auto,q_auto,w_auto/v1479811749/docs/github-org-permissions.png)
+
+If you'd like to integrate this organisation, you will need to [request organisational approval](https://help.github.com/articles/requesting-organization-approval-for-your-authorized-applications/) in GitHub.


### PR DESCRIPTION
- [x] Ready to be merged, pending review

#### What does this PR do?

Adds a section on Authorizing GitHub to the docs, based on a user query.

***

The section lives at the bottom of the "GitHub integration" section

![screen shot 2016-11-22 at 11 15 45](https://cloud.githubusercontent.com/assets/237149/20522002/e7c65838-b0a5-11e6-8803-5697d64fe389.png)

***

Link to the section further up the page.

![screen shot 2016-11-22 at 11 15 37](https://cloud.githubusercontent.com/assets/237149/20522001/e7c6586a-b0a5-11e6-91a4-b3a375f16c7d.png)
