### PR TITLE
Fix typo in link

### DIFF
--- a/_docs_landing/0_intro.md
+++ b/_docs_landing/0_intro.md
@@ -26,7 +26,7 @@ Check our [GitHub Enterprise documentation](https://snyk.io/docs/snyk-broker/). 
 
 ## Security at Snyk
 
-You can find out more about our security process and disclosure policy in our [security documenation](https://snyk.io/docs/security/).
+You can find out more about our security process and disclosure policy in our [security documentation](https://snyk.io/docs/security/).
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Replaces `documenation` with `documentation`.

Shortest PR ever.
