### PR TITLE
feat: change advice for CI envs to setting the SNYK_TOKEN env variable

### DIFF
--- a/_docs_ci/1_build-integration.md
+++ b/_docs_ci/1_build-integration.md
@@ -8,15 +8,7 @@ To continuously avoid known vulnerabilities in your Node.js dependencies, integr
 2. Run `snyk wizard` in the directory of your project following the prompts which will also generate a `.snyk` policy file. For more information about this, see [our CLI documentation](/docs/using-snyk/#wizard).
 3. Ensure the `.snyk` file you generated was added to your source control (`git add .snyk`).
 4. If you selected to, Snyk will include `snyk test` as part of your `npm test` command, so if there are new vulnerabilities in the future, your CI will fail, protecting you from introducing vulnerabilities to production. Alternatively, you can add `snyk test` to any other CI test platform you use.
+5. Configure your CI environment to include the `SNYK_TOKEN` environment variable. You can find your API token in your [account settings on snyk.io](https://snyk.io/account/).
 
-To stay secure over time, Snyk alerts you about newly disclosed vulnerabilities that affect your project's dependencies. 
-To make sure the list of dependencies we have for your project is up to date, refresh it continuously by running `snyk monitor` in your deployment process. You'll also need to authenticate to Snyk, so we know where to update the dependencies.
-
-To do both, add the following to your deployment scripts:
-
-```
-snyk auth $SNYK_TOKEN
-snyk monitor
-```
-
-Configure your environment to include the `SNYK_TOKEN` environment variable. You can find your API token in your [account settings on snyk.io](https://snyk.io/account/). 
+To stay secure over time, Snyk alerts you about newly disclosed vulnerabilities that affect your project's dependencies.
+To make sure the list of dependencies we have for your project is up to date, refresh it continuously by running `snyk monitor` in your deployment process.

--- a/_docs_ci/2_ruby-build-integration.md
+++ b/_docs_ci/2_ruby-build-integration.md
@@ -6,15 +6,7 @@ To continuously avoid known vulnerabilities in your Ruby dependencies, integrate
 
 1. Install the Snyk utility using `npm install -g snyk`.
 2. Add `snyk test` to your CI test platform
+3. Configure your environment to include the `SNYK_TOKEN` environment variable. You can find your API token in your [account settings on snyk.io](https://snyk.io/account/). 
 
-To stay secure over time, Snyk alerts you about newly disclosed vulnerabilities that affect your project's dependencies. 
-To make sure the list of dependencies we have for your project is up to date, refresh it continuously by running `snyk monitor` in your deployment process. You'll also need to authenticate to Snyk, so we know where to update the dependencies.
-
-To do both, add the following to your deployment scripts:
-
-```
-snyk auth $SNYK_TOKEN
-snyk monitor
-```
-
-Configure your environment to include the `SNYK_TOKEN` environment variable. You can find your API token in your [account settings on snyk.io](https://snyk.io/account/). 
+To stay secure over time, Snyk alerts you about newly disclosed vulnerabilities that affect your project's dependencies.
+To make sure the list of dependencies we have for your project is up to date, refresh it continuously by running `snyk monitor` in your deployment process.

--- a/_docs_quick-start/2_authentication.md
+++ b/_docs_quick-start/2_authentication.md
@@ -17,4 +17,4 @@ https://snyk.io/login?token=9b4ae29b-d430-4d79-b9a3-dd522e77f8b9
 Waiting...
 ```
 
-Once authenticated, the wizard will get an API token to store locally and get on with the testing. The same authentication process can be done by running `snyk auth`, or running `snyk auth <api-token>` (especially useful when integrating Snyk into your build/continuous integration (CI) system).
+Once authenticated, the wizard will get an API token to store locally and get on with the testing. The same authentication process can be done by running `snyk auth`, or setting the environment variable `SNYK_TOKEN` to your API token. You can find your API token in your [account settings on snyk.io](https://snyk.io/account/). 

--- a/_docs_using-snyk/02_authentication.md
+++ b/_docs_using-snyk/02_authentication.md
@@ -2,10 +2,6 @@
 title: Authentication
 ---
 
-Some Snyk commands require authentication. We use GitHub for authentication, but **do not require access to your repositories**, only your email address. You can authenticate by running `snyk auth` in your terminal, and it'll guide you through this process. 
+Some Snyk commands require authentication. We use GitHub for authentication, but **do not require access to your repositories**, only your email address. You can authenticate by running `snyk auth` in your terminal, and it'll guide you through this process.
 
-Alternatively, you can visit [your account](https://snyk.io/account), copy your token and paste it into your terminal as follows:
-
-```bash
-snyk auth <your token>
-```
+Alternatively, you can visit [your account](https://snyk.io/account), copy your token and set the environment variable `SNYK_TOKEN` to your token. This approach is recommended for CI environments.

--- a/_docs_using-snyk/07_dev-integration.md
+++ b/_docs_using-snyk/07_dev-integration.md
@@ -17,14 +17,7 @@ title: Integrating Snyk into your dev workflow
 2. Add `snyk test` to your CI test platform
 
 <h3>Setting up automatic monitoring</h3>
-If you monitor a project with Snyk, you'll get notified if your project's dependencies are affected by newly disclosed vulnerabilities. To make sure this list of dependencies is up to date, refresh it continuously by running `snyk monitor` in your deployment process. You'll also need to authenticate to Snyk, so we can know where to update the dependencies.
-
-To do both, add the following to your deployment scripts:
-
-```
-snyk auth $SNYK_TOKEN
-snyk monitor
-```
+If you monitor a project with Snyk, you'll get notified if your project's dependencies are affected by newly disclosed vulnerabilities. To make sure the list of dependencies we have for your project is up to date, refresh it continuously by running `snyk monitor` in your deployment process.
 
 Configure your environment to include the `SNYK_TOKEN` environment variable. You can find your API token on the dashboard after logging in.
 

--- a/_docs_using-snyk/10_troubleshooting.md
+++ b/_docs_using-snyk/10_troubleshooting.md
@@ -10,11 +10,7 @@ If your instance of the Snyk CLI has started failing, follow these steps to reso
    npm install -g snyk
    ```
 2. Make sure you are authenticating prior to running the Snyk CLI command
-   You can either authenticate by running `snyk auth` in your terminal, and it’ll guide you through this process, or visit [your account](https://snyk.io/account) and copy your API token and paste it into your terminal as follows:
-
-   ```bash
-   snyk auth <your token>
-   ```
+   You can either authenticate by running `snyk auth` in your terminal, and it’ll guide you through this process, or visit [your account](https://snyk.io/account), copy your API token and set the environment variable `SNYK_TOKEN` to your token.
 
 3. If you are still having problems after upgrading and authenticating send an email to [support@snyk.io](mailto:support@snyk.io) and we will help you out.
 


### PR DESCRIPTION
Previously we recommended that people run `snyk auth <API_TOKEN>`, but this doesn't work well locally. 

Instead, for CI envs, we should recommend people to set the `SNYK_TOKEN` variable to their token.

This change is made as a result of https://github.com/snyk/snyk/issues/68