### PR TITLE
docs: add java to feed json

### DIFF
--- a/feed.json
+++ b/feed.json
@@ -23,6 +23,16 @@ layout:
     "slug"     : {{ article.title | slugify | jsonify }},{% endif %}
     "content": {{ article.content | jsonify }}
   },
+  {% endfor %}{% assign java = site.docs_java | where: 'draft', 'false' %}{% for article in java %}
+  {
+    {% if article.title == "" %}{% else %}"title" : {{ article.title | jsonify }},
+    {% endif %}"docs_java" : "true",
+    "topic" : "java",
+    "topicSlug" : "snyk-for-java",
+    "url"     : "/docs/java/{{ article.title | slugify }}",{% if article.title %}
+    "slug"     : {{ article.title | slugify | jsonify }},{% endif %}
+    "content": {{ article.content | jsonify }}
+  },
   {% endfor %}{% assign ruby = site.docs_ruby | where: 'draft', 'false' %}{% for article in ruby %}
   {
     {% if article.title == "" %}{% else %}"title" : {{ article.title | jsonify }},


### PR DESCRIPTION
I'm not entirely sure why this is required, but it looks important - for when you get back..