### PR TITLE
feat: add a link to the support section to our docs landing page

### DIFF
--- a/_docs_landing/0_intro.md
+++ b/_docs_landing/0_intro.md
@@ -41,8 +41,12 @@ Check our [GitHub Enterprise documentation](https://snyk.io/docs/snyk-broker/). 
 
 You can find out more about our security process and disclosure policy in our [security documentation](https://snyk.io/docs/security/).
 
-## Frequently Asked Questions
+## We're here to help!
 
-Our [FAQs](https://snyk.io/docs/faqs/) answer questions you might have about known vulnerabilities, fixing vulnerabilities, using Snyk behind a proxy, and more.
+### Support
 
-**Need help with anything you can’t find here?** [Drop us a line](mailto:support@snyk.io) and we’ll get right back to you.
+If you have any questions that need answering, you might find an answer on our [support section](https://support.snyk.io).
+
+### Need help with anything you can’t find here?
+
+[Drop us a line](mailto:support@snyk.io) and we’ll get right back to you.


### PR DESCRIPTION
The nav bar link is coming as part of a separate of https://github.com/snyk/registry/pull/2221

<img width="709" alt="screen shot 2017-05-11 at 13 55 22" src="https://cloud.githubusercontent.com/assets/813784/25945936/8a4f0fd8-3651-11e7-8ec1-8159ce32f442.png">
