### PR TITLE
fix: generic SCM reference instead of GHE

### DIFF
--- a/_docs_broker/4_broker-client-setup.md
+++ b/_docs_broker/4_broker-client-setup.md
@@ -2,6 +2,8 @@
 title: "Broker client"
 ---
 
-The broker client is a web server which securely relays requests between Snyk's servers and your GitHub Enterprise. It needs to run on a network which has both outbound internet access and access to your GitHub Enterprise.
+The broker client is a web server which securely relays requests between Snyk's servers and your repositories hosted on supported SCMs. It needs to run on a network which has both outbound internet access and access to your SCM.
 
 The broker client is best installed as a docker image. See the [Dockerhub page](https://hub.docker.com/r/snyk/broker/) for further details on installing and configuring your broker client.
+
+The broker is an open source project hosted at [GitHub](https://github.com/snyk/broker).


### PR DESCRIPTION
A bit more generic reference to the broker client.