### PR TITLE
fix: show correct red badge for bad

### DIFF
--- a/_docs_badges/0_intro.md
+++ b/_docs_badges/0_intro.md
@@ -10,4 +10,4 @@ If there are no vulnerabilities, this is indicated by a green badge.
 
 If vulnerabilities have been found, the red badge will show the number of vulnerabilities.
 
-<a class="link--unstyled" href="https://snyk.io/test/npm/jsbin"><img src="https://snyk.io/test/npm/jsbin/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/npm/jsbin/" style="max-width:100%;"></a>
+<a class="link--unstyled" href="https://snyk.io/test/github/snyk/goof"><img src="https://snyk.io/test/github/snyk/goof/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/snyk/goof" style="max-width:100%;"></a>


### PR DESCRIPTION
Previously pointed to jsbin as an example, but jsbin was clean of vulns
since early 2017. snyk/goof is also a great example to link through to
as it'll always remain vulnerable.

Send my love to the old team ❤️ 