### PR TITLE
feat: docs state that API use is available only on paid plans

### DIFF
--- a/_docs_landing/1_api.md
+++ b/_docs_landing/1_api.md
@@ -2,8 +2,8 @@
 title: "API"
 ---
 
-Looking to build something bespoke? You can use our API to access information about issues affecting your projects. We've written a blog post which [introduces working with the API](https://snyk.io/blog/using-the-snyk-api-to-get-your-vulnerabilities/).
+Looking to build something bespoke? Customers on paid plans can use our API to access information about issues affecting your projects. We've written a blog post which [introduces working with the API](https://snyk.io/blog/using-the-snyk-api-to-get-your-vulnerabilities/).
 
-Read the complete [API Documentation](https://snyk.docs.apiary.io).
+Read the complete [API Documentation](https://snyk.docs.apiary.io), or visit the [plans](https://snyk.io/plans) to get started.
 
 [Let us know](mailto:support@snyk.io) if you've got any questions or suggestions. We'd love to hear how you're using the API.


### PR DESCRIPTION
Updates docs wording to specify that the API is only available on a paid plan.