### PR TITLE
fix: missing licenses in docs feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,3 +56,4 @@ collections:
   - docs_bitbucket-server
   - docs_groups
   - docs_reports
+  - docs_licenses


### PR DESCRIPTION
Does what it says on the tin.