### PR TITLE
docs: remove unneeded admin:repo_hook GitHub scope

### DIFF
--- a/_docs_broker/2_github-setup.md
+++ b/_docs_broker/2_github-setup.md
@@ -2,14 +2,14 @@
 title: "GitHub / GitHub Enterprise setup"
 ---
 
-In order to interact with your GitHub.com or GitHub Enterprise repositories, Snyk needs to use a personal access token with "repo" and "admin:repo_hook" scopes.
+In order to interact with your GitHub.com or GitHub Enterprise repositories, Snyk needs to use a personal access token with "repo" scope.
 
 To create a GitHub personal access token:
 
  1. log in to your GitHub.com or GitHub Enterprise account
  2. navigate to "/settings/tokens" in your web browser. e.g. for GitHub.com, go to [https://github.com/settings/tokens](https://github.com/settings/tokens)
  3. click on the "Generate new token" button
- 4. enter a description for the token, and select the "**repo**" and "**admin:repo_hook**" scope
+ 4. enter a description for the token, and select the "**repo**" scope
  5. click on the "Generate token" button
  6. securely save the token so that you can configure your Broker client with it
 


### PR DESCRIPTION
GitHub have confirmed that only the `repo` scope is needed administer webhook on a repository, and have acknowledged that their docs are currently misleading on this issue.